### PR TITLE
client credentials grant exposed

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -258,6 +258,36 @@ class Auth0
         exit;
     }
 
+    public function clientCredentials()
+    {
+        $params = [];
+        if ($this->audience) {
+            $params['audience'] = $this->audience;
+        }
+        if ($this->scope) {
+            $params['scope'] = $this->scope;
+        }
+
+        $params['response_mode'] = $this->response_mode;
+
+        $response = $this->authentication->client_credentials($params);
+
+        $access_token = (isset($response['access_token'])) ? $response['access_token'] : false;
+        $refresh_token = false;
+        $id_token = false;
+
+        if (!$access_token) {
+            throw new ApiException('Unable to retrieve access token. Invalid credentials.');
+        }
+
+        $this->setAccessToken($access_token);
+        $this->setIdToken($id_token);
+        $this->setRefreshToken($refresh_token);
+
+        return true;
+    }
+
+
     public function getUser()
     {
         if ($this->user) {


### PR DESCRIPTION
client credentials grant was not exposed in the Auth0 sdk. Added this method for using Auth0 as the oauth server for DoThat APIs